### PR TITLE
feat: Implement multi-select filters with manual apply button

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,6 +192,23 @@
       color: #34495e;
     }
 
+    .apply-filters-btn {
+      padding: 10px 20px;
+      border: none;
+      background-color: var(--main-green);
+      color: white;
+      font-size: 1rem;
+      font-weight: 500;
+      border-radius: 8px;
+      cursor: pointer;
+      transition: background-color 0.3s ease, transform 0.2s ease;
+      margin-left: 15px; /* Add some space between the last filter and the button */
+    }
+
+    .apply-filters-btn:hover {
+      background-color: #257a4a; /* A darker shade of the main green */
+      transform: translateY(-1px);
+    }
 
     .section-nav-buttons {
       margin-left: auto; /* Push buttons to the right */
@@ -825,6 +842,7 @@
           </div>
         </div>
       </div>
+      <button id="applyFiltersBtn" class="apply-filters-btn">Apply Filters</button>
       <div class="section-nav-buttons">
         <button id="btn-total-ghg" onclick="scrollToSection('total-ghg-section')">Total GHG</button>
         <button id="btn-scope1" onclick="scrollToSection('scope1-section')">Scope 1</button>
@@ -1263,6 +1281,7 @@
     const monthBtnText = document.getElementById('monthBtnText');
     const yearBtnText = document.getElementById('yearBtnText');
     const plantBtnText = document.getElementById('plantBtnText');
+    const applyFiltersBtn = document.getElementById('applyFiltersBtn');
 
     const loadingSpinner = document.getElementById('loadingSpinner');
     const errorMessage = document.getElementById('errorMessage');
@@ -1433,9 +1452,6 @@
                 btnText.textContent = allText; // Fallback
             }
 
-            // Debounce updateDashboard call
-            clearTimeout(window.dashboardUpdateTimeout);
-            window.dashboardUpdateTimeout = setTimeout(updateDashboard, 500);
         });
 
         // Close dropdown when clicking outside
@@ -1486,6 +1502,9 @@
         setupMultiSelect(monthFilterContainer, monthFilterBtn, monthListItems, monthBtnText, 'All Months');
         setupMultiSelect(yearFilterContainer, yearFilterBtn, yearListItems, yearBtnText, 'All Years');
         setupMultiSelect(plantFilterContainer, plantFilterBtn, plantListItems, plantBtnText, 'All Plants');
+
+        // Add event listener for the apply button
+        applyFiltersBtn.addEventListener('click', updateDashboard);
     }
 
 


### PR DESCRIPTION
- Replaced single-select dropdowns for "Month Coverage", "Year Coverage", and "Plants" with custom multi-select checkbox components.
- Modified `index.html` with a new `div`-based structure and CSS to create and style the multi-select dropdowns.
- Updated JavaScript to manage the new components, handle user selections, and update the display text.
- Added an "Apply Filters" button to the UI.
- Removed the automatic data refresh on selection change. The dashboard now only updates when the "Apply Filters" button is clicked.
- Modified `code.gs` to update the `getDashboardData` function to accept and process arrays of filter values, aligning with the new frontend implementation.